### PR TITLE
Add streaming support for read and write operations

### DIFF
--- a/components/org.wso2.carbon.transport.remote-file-system/pom.xml
+++ b/components/org.wso2.carbon.transport.remote-file-system/pom.xml
@@ -70,7 +70,6 @@
         <dependency>
             <groupId>commons-io.wso2</groupId>
             <artifactId>commons-io</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockftpserver</groupId>

--- a/components/org.wso2.carbon.transport.remote-file-system/src/main/java/org/wso2/carbon/transport/remotefilesystem/client/connector/contractimpl/FileObjectInputStream.java
+++ b/components/org.wso2.carbon.transport.remote-file-system/src/main/java/org/wso2/carbon/transport/remotefilesystem/client/connector/contractimpl/FileObjectInputStream.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.transport.remotefilesystem.client.connector.contractimpl;
+
+import org.apache.commons.vfs2.FileObject;
+import org.apache.commons.vfs2.util.MonitorInputStream;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * This class will wrapped the original InputStream along with the FileObject. This will allow to close both stream
+ * properly once it usage is done.
+ */
+public class FileObjectInputStream extends MonitorInputStream {
+
+    private FileObject path;
+
+    FileObjectInputStream(InputStream originalInputStream, FileObject path) {
+        super(originalInputStream);
+        this.path = path;
+    }
+
+    @Override
+    public void close() throws IOException {
+        super.close();
+        if (path != null) {
+            path.close();
+        }
+    }
+}

--- a/components/org.wso2.carbon.transport.remote-file-system/src/main/java/org/wso2/carbon/transport/remotefilesystem/message/RemoteFileSystemMessage.java
+++ b/components/org.wso2.carbon.transport.remote-file-system/src/main/java/org/wso2/carbon/transport/remotefilesystem/message/RemoteFileSystemMessage.java
@@ -19,14 +19,20 @@
 package org.wso2.carbon.transport.remotefilesystem.message;
 
 import java.io.InputStream;
+import java.nio.ByteBuffer;
 
 /**
  * This represent the message that hold payload and other attributes.
  */
 public class RemoteFileSystemMessage extends RemoteFileSystemBaseMessage {
 
+    private ByteBuffer bytes;
     private InputStream inputStream;
     private String text;
+
+    public RemoteFileSystemMessage(ByteBuffer bytes) {
+        this.bytes = bytes;
+    }
 
     public RemoteFileSystemMessage(InputStream inputStream) {
         this.inputStream = inputStream;
@@ -34,6 +40,10 @@ public class RemoteFileSystemMessage extends RemoteFileSystemBaseMessage {
 
     public RemoteFileSystemMessage(String text) {
         this.text = text;
+    }
+
+    public ByteBuffer getBytes() {
+        return bytes;
     }
 
     public InputStream getInputStream() {

--- a/components/org.wso2.carbon.transport.remote-file-system/src/main/java/org/wso2/carbon/transport/remotefilesystem/message/RemoteFileSystemMessage.java
+++ b/components/org.wso2.carbon.transport.remote-file-system/src/main/java/org/wso2/carbon/transport/remotefilesystem/message/RemoteFileSystemMessage.java
@@ -18,26 +18,26 @@
 
 package org.wso2.carbon.transport.remotefilesystem.message;
 
-import java.nio.ByteBuffer;
+import java.io.InputStream;
 
 /**
  * This represent the message that hold payload and other attributes.
  */
 public class RemoteFileSystemMessage extends RemoteFileSystemBaseMessage {
 
-    private ByteBuffer bytes;
+    private InputStream inputStream;
     private String text;
 
-    public RemoteFileSystemMessage(ByteBuffer bytes) {
-        this.bytes = bytes;
+    public RemoteFileSystemMessage(InputStream inputStream) {
+        this.inputStream = inputStream;
     }
 
     public RemoteFileSystemMessage(String text) {
         this.text = text;
     }
 
-    public ByteBuffer getBytes() {
-        return bytes;
+    public InputStream getInputStream() {
+        return inputStream;
     }
 
     public String getText() {

--- a/components/org.wso2.carbon.transport.remote-file-system/src/test/java/org/wso2/carbon/transport/remotefilesystem/client/RemoteFileSystemClientConnectorTestCase.java
+++ b/components/org.wso2.carbon.transport.remote-file-system/src/test/java/org/wso2/carbon/transport/remotefilesystem/client/RemoteFileSystemClientConnectorTestCase.java
@@ -37,9 +37,11 @@ import org.wso2.carbon.transport.remotefilesystem.impl.RemoteFileSystemConnector
 import org.wso2.carbon.transport.remotefilesystem.message.RemoteFileSystemMessage;
 
 import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
@@ -144,7 +146,8 @@ public class RemoteFileSystemClientConnectorTestCase {
         TestReadActionListener fileSystemListener = new TestReadActionListener(latch);
         VFSClientConnector clientConnector =
                 connectorFactory.createVFSClientConnector(parameters, fileSystemListener);
-        RemoteFileSystemMessage message = new RemoteFileSystemMessage(ByteBuffer.wrap(newContent.getBytes()));
+        InputStream stream = new ByteArrayInputStream(newContent.getBytes(StandardCharsets.UTF_8));
+        RemoteFileSystemMessage message = new RemoteFileSystemMessage(stream);
         clientConnector.send(message);
         latch.await(3, TimeUnit.SECONDS);
         FileEntry entry = (FileEntry) fileSystem.getEntry("/home/wso2/file2.txt");
@@ -152,6 +155,11 @@ public class RemoteFileSystemClientConnectorTestCase {
         String fileContent = new BufferedReader(new InputStreamReader(inputStream)).lines().
                 collect(Collectors.joining("\n"));
         Assert.assertEquals(fileContent, newContent, "File content invalid.");
+        try {
+            stream.close();
+        } catch (IOException e) {
+            //Ignore the exception.
+        }
     }
 
     @Test(description = "Write content by creating new file")
@@ -167,7 +175,8 @@ public class RemoteFileSystemClientConnectorTestCase {
         TestReadActionListener fileSystemListener = new TestReadActionListener(latch);
         VFSClientConnector clientConnector =
                 connectorFactory.createVFSClientConnector(parameters, fileSystemListener);
-        RemoteFileSystemMessage message = new RemoteFileSystemMessage(ByteBuffer.wrap(newContent.getBytes()));
+        InputStream stream = new ByteArrayInputStream(newContent.getBytes(StandardCharsets.UTF_8));
+        RemoteFileSystemMessage message = new RemoteFileSystemMessage(stream);
         clientConnector.send(message);
         latch.await(3, TimeUnit.SECONDS);
         FileEntry entry = (FileEntry) fileSystem.getEntry("/home/wso2/file4.txt");
@@ -175,6 +184,11 @@ public class RemoteFileSystemClientConnectorTestCase {
         String fileContent = new BufferedReader(new InputStreamReader(inputStream)).lines().
                 collect(Collectors.joining("\n"));
         Assert.assertEquals(fileContent, newContent, "File content invalid.");
+        try {
+            stream.close();
+        } catch (IOException e) {
+            //Ignore the exception.
+        }
     }
 
     @Test(description = "Check file content append.", dependsOnMethods = "fileContentReadTestCase")
@@ -191,7 +205,8 @@ public class RemoteFileSystemClientConnectorTestCase {
         TestReadActionListener fileSystemListener = new TestReadActionListener(latch);
         VFSClientConnector clientConnector =
                 connectorFactory.createVFSClientConnector(parameters, fileSystemListener);
-        RemoteFileSystemMessage message = new RemoteFileSystemMessage(ByteBuffer.wrap(newContent.getBytes()));
+        InputStream stream = new ByteArrayInputStream(newContent.getBytes(StandardCharsets.UTF_8));
+        RemoteFileSystemMessage message = new RemoteFileSystemMessage(stream);
         clientConnector.send(message);
         latch.await(3, TimeUnit.SECONDS);
         FileEntry entry = (FileEntry) fileSystem.getEntry("/home/wso2/file1.txt");
@@ -199,6 +214,11 @@ public class RemoteFileSystemClientConnectorTestCase {
         String fileContent = new BufferedReader(new InputStreamReader(inputStream)).lines().
                 collect(Collectors.joining("\n"));
         Assert.assertEquals(fileContent, content + newContent, "File content invalid.");
+        try {
+            stream.close();
+        } catch (IOException e) {
+            //Ignore the exception.
+        }
     }
 
     @Test(description = "Create new file.")

--- a/components/org.wso2.carbon.transport.remote-file-system/src/test/java/org/wso2/carbon/transport/remotefilesystem/client/TestReadActionListener.java
+++ b/components/org.wso2.carbon.transport.remote-file-system/src/test/java/org/wso2/carbon/transport/remotefilesystem/client/TestReadActionListener.java
@@ -22,7 +22,10 @@ import org.wso2.carbon.transport.remotefilesystem.listener.RemoteFileSystemListe
 import org.wso2.carbon.transport.remotefilesystem.message.RemoteFileSystemBaseMessage;
 import org.wso2.carbon.transport.remotefilesystem.message.RemoteFileSystemMessage;
 
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
 import java.util.concurrent.CountDownLatch;
+import java.util.stream.Collectors;
 
 /**
  * Test {@link RemoteFileSystemListener} implementation for testing purpose.
@@ -40,7 +43,8 @@ public class TestReadActionListener implements RemoteFileSystemListener {
     @Override
     public boolean onMessage(RemoteFileSystemBaseMessage remoteFileSystemBaseMessage) {
         RemoteFileSystemMessage message = (RemoteFileSystemMessage) remoteFileSystemBaseMessage;
-        content = new String(message.getBytes().array());
+        content = new BufferedReader(new InputStreamReader(message.getInputStream())).lines()
+                .collect(Collectors.joining("\n"));
         latch.countDown();
         return true;
     }

--- a/components/org.wso2.carbon.transport.remote-file-system/src/test/java/org/wso2/carbon/transport/remotefilesystem/server/RemoteFileSystemServerConnectorTestCase.java
+++ b/components/org.wso2.carbon.transport.remote-file-system/src/test/java/org/wso2/carbon/transport/remotefilesystem/server/RemoteFileSystemServerConnectorTestCase.java
@@ -87,9 +87,10 @@ public class RemoteFileSystemServerConnectorTestCase {
         }
         Assert.assertEquals(eventList.size(), expectedEventCount, "Generated events count mismatch " +
                 "with the expected.");
-        Assert.assertTrue(eventList.contains(buildConnectionURL() + "/exe/run.exe"));
-        Assert.assertTrue(eventList.contains(buildConnectionURL() + "/file1.txt"));
-        Assert.assertTrue(eventList.contains(buildConnectionURL() + "/file2.txt"));
+        Assert.assertTrue(eventList.contains(buildConnectionURL() + "/exe/run.exe"), "run.exe didn't received.");
+        Assert.assertTrue(eventList.contains(buildConnectionURL() + "/file1.txt"), "file1 didn't received.");
+        Assert.assertTrue(eventList.contains(buildConnectionURL() + "/file2.txt"), "file2 didn't received.");
+        fileSystem.delete("/home/wso2/file2.txt");
         testConnector.stop();
     }
 
@@ -114,8 +115,8 @@ public class RemoteFileSystemServerConnectorTestCase {
         }
         Assert.assertEquals(eventList.size(), expectedEventCount, "Generated events count mismatch " +
                 "with the expected.");
-        Assert.assertTrue(eventList.contains(buildConnectionURL() + "/exe/run.exe"));
-        Assert.assertTrue(eventList.contains(buildConnectionURL() + "/file1.txt"));
+        Assert.assertTrue(eventList.contains(buildConnectionURL() + "/exe/run.exe"), "run.exe didn't received.");
+        Assert.assertTrue(eventList.contains(buildConnectionURL() + "/file1.txt"), "file1 didn't received.");
         testConnector.stop();
     }
 

--- a/components/org.wso2.carbon.transport.remote-file-system/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.transport.remote-file-system/src/test/resources/testng.xml
@@ -19,7 +19,7 @@
   -->
 
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
-<suite name="Transport test Suite">
+<suite name="Transport test Suite" parallel="false">
 
     <test name="Transport test">
         <classes>

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,6 @@
                 <groupId>commons-io.wso2</groupId>
                 <artifactId>commons-io</artifactId>
                 <version>${commons-io.wso2.version}</version>
-                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>commons-net</groupId>


### PR DESCRIPTION
## Purpose
Add streaming support for read and write operation.

## Goals
The previous implementation used to load the entire content to the memory. This will cause OOM situation. Now read operation will result input stream instead of a byte array.

## Approach
Return input stream instead of a byte array.

## Release note
Add streaming support for read and write operations
