### PR TITLE
Allow retrieving additional file information

### DIFF
--- a/components/org.wso2.transport.remote-file-system/src/main/java/org/wso2/transport/remotefilesystem/client/connector/contractimpl/VFSClientConnectorImpl.java
+++ b/components/org.wso2.transport.remote-file-system/src/main/java/org/wso2/transport/remotefilesystem/client/connector/contractimpl/VFSClientConnectorImpl.java
@@ -31,6 +31,7 @@ import org.wso2.transport.remotefilesystem.client.connector.contract.FtpAction;
 import org.wso2.transport.remotefilesystem.client.connector.contract.VFSClientConnector;
 import org.wso2.transport.remotefilesystem.exception.RemoteFileSystemConnectorException;
 import org.wso2.transport.remotefilesystem.listener.RemoteFileSystemListener;
+import org.wso2.transport.remotefilesystem.message.FileInfo;
 import org.wso2.transport.remotefilesystem.message.RemoteFileSystemMessage;
 import org.wso2.transport.remotefilesystem.server.util.FileTransportUtils;
 
@@ -39,6 +40,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -167,13 +169,13 @@ public class VFSClientConnectorImpl implements VFSClientConnector {
                     remoteFileSystemListener.onMessage(new RemoteFileSystemMessage(path.getContent().getSize()));
                     break;
                 case LIST:
-                    final FileObject[] pathObjects = path.getChildren();
-                    String[] childrenNames = new String[pathObjects.length];
-                    int i = 0;
-                    for (FileObject child : pathObjects) {
-                        childrenNames[i++] = child.getName().getPath();
+                    final FileObject[] fileObjects = path.getChildren();
+                    Map<String, FileInfo> childrenInfo = new HashMap<>();
+                    for (FileObject fileObject : fileObjects) {
+                        FileInfo fileInfo = new FileInfo(fileObject);
+                        childrenInfo.put(fileInfo.getBaseName(), fileInfo);
                     }
-                    RemoteFileSystemMessage children = new RemoteFileSystemMessage(childrenNames);
+                    RemoteFileSystemMessage children = new RemoteFileSystemMessage(childrenInfo);
                     remoteFileSystemListener.onMessage(children);
                     break;
                 case ISDIR:

--- a/components/org.wso2.transport.remote-file-system/src/main/java/org/wso2/transport/remotefilesystem/message/FileInfo.java
+++ b/components/org.wso2.transport.remote-file-system/src/main/java/org/wso2/transport/remotefilesystem/message/FileInfo.java
@@ -18,17 +18,111 @@
 
 package org.wso2.transport.remotefilesystem.message;
 
+import org.apache.commons.vfs2.FileName;
+import org.apache.commons.vfs2.FileObject;
+import org.apache.commons.vfs2.FileSystemException;
+import org.apache.commons.vfs2.FileType;
+
+import java.net.URL;
+
 /**
  * This represent meta details of the remote file.
  */
 public class FileInfo {
 
+    /**
+     * Relative file path for newly added file
+     */
     private final String path;
+
+    /**
+     * Size of the file
+     */
     private long fileSize;
+
+    /**
+     * Last modified timestamp of the file in UNIX Epoch time
+     */
     private long lastModifiedTime;
+
+    /**
+     * The name of this file
+     */
+    private FileName fileName;
+
+    /**
+     * The receiver as a URI String for public display
+     */
+    private String publicURIString;
+
+    /**
+     * File's type
+     */
+    private FileType fileType;
+
+    /**
+     * Whether the fileObject is attached
+     */
+    private boolean isAttached;
+
+    /**
+     * The URL representation of this file.
+     */
+    private URL url;
+
+    /**
+     * Whether someone reads/writes to this file
+     */
+    private boolean isContentOpen;
+
+    /**
+     * Whether this file is executable
+     */
+    private boolean isExecutable;
+
+    /**
+     * Whether the file is a file or not
+     */
+    private boolean isFile;
+
+    /**
+     * Whether the file is a folder or not
+     */
+    private boolean isFolder;
+
+    /**
+     * Whether this file is hidden
+     */
+    private boolean isHidden;
+
+    /**
+     * Whether this file can be read
+     */
+    private boolean isReadable;
+
+    /**
+     * Whether this file can be written to
+     */
+    private boolean isWritable;
 
     public FileInfo(String path) {
         this.path = path;
+    }
+
+    public FileInfo(FileObject fileObject) throws FileSystemException {
+        this.fileName = fileObject.getName();
+        this.path = fileName.getPath();
+        this.publicURIString = fileObject.getPublicURIString();
+        this.isFolder = fileObject.isFolder();
+        this.isFile = fileObject.isFile();
+        this.fileType = fileObject.getType();
+        this.isAttached = fileObject.isAttached();
+        this.url = fileObject.getURL();
+        this.isContentOpen = fileObject.isContentOpen();
+        this.isExecutable = fileObject.isExecutable();
+        this.isHidden = fileObject.isHidden();
+        this.isReadable = fileObject.isReadable();
+        this.isWritable = fileObject.isWriteable();
     }
 
     /**
@@ -64,5 +158,122 @@ public class FileInfo {
 
     public void setLastModifiedTime(long lastModifiedTime) {
         this.lastModifiedTime = lastModifiedTime;
+    }
+
+    /**
+     * Returns the base name of this file. The base name is the last element of the file name. F
+     *
+     * @return The base name. Never returns null.
+     */
+    public String getBaseName() {
+        return this.fileName.getBaseName();
+    }
+
+    /**
+     * Returns the name of this file.
+     *
+     * @return the FileName.
+     */
+    public FileName getFileName() {
+        return fileName;
+    }
+
+    /**
+     * Returns the receiver as a URI String for public display, like, without a password.
+     *
+     * @return A URI String without a password.
+     */
+    public String getPublicURIString() {
+        return publicURIString;
+    }
+
+    /**
+     * Returns this file's type.
+     *
+     * @return One of the {@link FileType} constants. Never returns null.
+     */
+    public FileType getFileType() {
+        return fileType;
+    }
+
+    /**
+     * Checks if the fileObject is attached.
+     *
+     * @return true if the FileObject is attached.
+     */
+    public boolean isAttached() {
+        return isAttached;
+    }
+
+    /**
+     * Returns a URL representing this file.
+     *
+     * @return the URL for the file.
+     */
+    public URL getUrl() {
+        return url;
+    }
+
+    /**
+     * Checks if someone reads/write to this file.
+     *
+     * @return true if the file content is open.
+     */
+    public boolean isContentOpen() {
+        return isContentOpen;
+    }
+
+    /**
+     * Determines if this file is executable.
+     *
+     * @return {@code true} if this file is executable, {@code false} if not.
+     */
+    public boolean isExecutable() {
+        return isExecutable;
+    }
+
+    /**
+     * Checks if this file is a regular file.
+     *
+     * @return true if this file is a regular file.
+     */
+    public boolean isFile() {
+        return isFile;
+    }
+
+    /**
+     * Checks if this file is a folder.
+     *
+     * @return true if this file is a folder.
+     */
+    public boolean isFolder() {
+        return isFolder;
+    }
+
+    /**
+     * Determines if this file is hidden.
+     *
+     * @return {@code true} if this file is hidden, {@code false} if not.
+     */
+    public boolean isHidden() {
+        return isHidden;
+    }
+
+    /**
+     * Determines if this file can be read.
+     *
+     * @return {@code true} if this file is readable, {@code false} if not.
+     */
+    public boolean isReadable() {
+        return isReadable;
+    }
+
+    /**
+     * Determines if this file can be written to.
+     *
+     * @return {@code true} if this file is writeable, {@code false} if not.
+     */
+    public boolean isWritable() {
+        return isWritable;
     }
 }

--- a/components/org.wso2.transport.remote-file-system/src/main/java/org/wso2/transport/remotefilesystem/message/RemoteFileSystemMessage.java
+++ b/components/org.wso2.transport.remote-file-system/src/main/java/org/wso2/transport/remotefilesystem/message/RemoteFileSystemMessage.java
@@ -20,6 +20,8 @@ package org.wso2.transport.remotefilesystem.message;
 
 import java.io.InputStream;
 import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.Map;
 
 /**
  * This represent the message that hold payload and other attributes.
@@ -30,8 +32,12 @@ public class RemoteFileSystemMessage extends RemoteFileSystemBaseMessage {
     private InputStream inputStream;
     private String text;
     private long size;
-    private String[] childNames;
     private boolean directory;
+    private Map<String, FileInfo> childrenInfo;
+
+    public RemoteFileSystemMessage(final Map<String, FileInfo> childrenInfo) {
+        this.childrenInfo = Collections.unmodifiableMap(childrenInfo);
+    }
 
     public RemoteFileSystemMessage(ByteBuffer bytes) {
         this.bytes = bytes;
@@ -47,10 +53,6 @@ public class RemoteFileSystemMessage extends RemoteFileSystemBaseMessage {
 
     public RemoteFileSystemMessage(long size) {
         this.size = size;
-    }
-
-    public RemoteFileSystemMessage(final String[] childNames) {
-        this.childNames = childNames.clone();
     }
 
     public RemoteFileSystemMessage(boolean isDirectory) {
@@ -74,7 +76,11 @@ public class RemoteFileSystemMessage extends RemoteFileSystemBaseMessage {
     }
 
     public String[] getChildNames() {
-        return childNames.clone();
+        return (String[]) (childrenInfo.keySet()).toArray();
+    }
+
+    public Map<String, FileInfo> getChildrenInfo() {
+        return childrenInfo;
     }
 
     public boolean isDirectory() {


### PR DESCRIPTION
## Purpose
In order to allow retrieve additional information of a file/folder, new parameters, which are coming from FileObject instances, have been introduced to the FileInfo object.

Related to https://github.com/wso2-ballerina/module-ftp/issues/53