### PR TITLE
Add current file position to CarbonMessage

### DIFF
--- a/components/org.wso2.transport.file/src/main/java/org/wso2/transport/file/connector/server/FileConsumer.java
+++ b/components/org.wso2.transport.file/src/main/java/org/wso2/transport/file/connector/server/FileConsumer.java
@@ -268,10 +268,10 @@ public class FileConsumer {
                 if (ch == 10) {
                     Byte[] line = new Byte[list.size()];
                     line = list.toArray(line);
-                    EventListener.fileUpdated(line, messageProcessor, serviceName);
+                    rePos = pos + (long) i + 1L;
+                    EventListener.fileUpdated(line, messageProcessor, serviceName, rePos);
                     lines++;
                     list.clear();
-                    rePos = pos + (long) i + 1L;
                 } else {
                     list.add(ch);
                 }
@@ -295,7 +295,7 @@ public class FileConsumer {
 
     private static int read(RandomAccessContent reader, byte[] inbuf) throws IOException {
         InputStream is = reader.getInputStream();
-        int count  = is.read(inbuf);
+        int count = is.read(inbuf);
         return count;
     }
 
@@ -316,15 +316,15 @@ public class FileConsumer {
             }
         }
 
-        private static void fileUpdated(Byte[] content, CarbonMessageProcessor messageProcessor, String serviceName)
-                throws FileServerConnectorException {
+        private static void fileUpdated(Byte[] content, CarbonMessageProcessor messageProcessor, String serviceName,
+                                        long currentPosition) throws FileServerConnectorException {
             try {
                 CarbonMessage cMessage = new BinaryCarbonMessage(ByteBuffer.wrap(toPrimitives(content)), true);
                 cMessage.setProperty(org.wso2.carbon.messaging.Constants.PROTOCOL, Constants.PROTOCOL_FILE);
                 cMessage.setProperty(Constants.FILE_TRANSPORT_PROPERTY_SERVICE_NAME, serviceName);
                 cMessage.setProperty(Constants.FILE_TRANSPORT_EVENT_NAME, Constants.FILE_UPDATE);
                 cMessage.setProperty(Constants.SINGLE_THREADED_EXECUTION, serviceName);
-
+                cMessage.setProperty(Constants.CURRENT_POSITION, currentPosition);
                 messageProcessor.receive(cMessage, null);
             } catch (Exception e) {
                 throw new FileServerConnectorException("Failed to send event message processor. ", e);

--- a/components/org.wso2.transport.file/src/main/java/org/wso2/transport/file/connector/server/util/Constants.java
+++ b/components/org.wso2.transport.file/src/main/java/org/wso2/transport/file/connector/server/util/Constants.java
@@ -33,6 +33,7 @@ public final class Constants {
     //file connector parameters
     public static final String TRANSPORT_FILE_FILE_PATH = "path";
     public static final String START_POSITION = "startPosition";
+    public static final String CURRENT_POSITION = "currentPosition";
     public static final String MAX_LINES_PER_POLL = "maxLinesPerPoll";
 
     public static final String SCHEME = "VFS_SCHEME";


### PR DESCRIPTION
## Purpose
> $subject to fix https://github.com/siddhi-io/siddhi-io-file/issues/58

## Goals
> Get the correct position of the read file so, when creating the FileConsumer, it can be created with the previous position

## Approach
> Add the position as a parameter and read it and save when reading the message.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes