### PR TITLE
Add EOF and File path properties as transport properties.

### DIFF
--- a/components/org.wso2.transport.file/src/main/java/org/wso2/transport/file/connector/sender/VFSClientConnector.java
+++ b/components/org.wso2.transport.file/src/main/java/org/wso2/transport/file/connector/sender/VFSClientConnector.java
@@ -167,7 +167,7 @@ public class VFSClientConnector implements ClientConnector {
                             path.moveTo(newPath);
                         } else {
                             throw new ClientConnectorException("The file at " + newPath.getURL().toString() +
-                                                                       " already exists or it is a directory");
+                                    " already exists or it is a directory");
                         }
                     } else {
                         throw new ClientConnectorException(
@@ -185,15 +185,30 @@ public class VFSClientConnector implements ClientConnector {
                         String filePath =  path.getName().getPath();
                         String fileExtension = filePath.substring(filePath.lastIndexOf(".") + 1);
                         String mode = map.get(Constants.MODE);
-                        if (mode != null && Constants.MODE_TYPE_LINE.equalsIgnoreCase(mode) &&
+                        if (Constants.MODE_TYPE_LINE.equalsIgnoreCase(mode) &&
                                 !fileExtension.equalsIgnoreCase(Constants.BINARY_FILE_EXTENSION)) {
                             bufferedReader = Files.newBufferedReader(Paths.get(filePath));
                             String line;
-                            while ((line = bufferedReader.readLine()) != null) {
-                                BinaryCarbonMessage message = new BinaryCarbonMessage(ByteBuffer.
+                            BinaryCarbonMessage message;
+                            line = bufferedReader.readLine();
+                            while (line != null) {
+                                message = new BinaryCarbonMessage(ByteBuffer.
                                         wrap(line.getBytes(StandardCharsets.UTF_8)), true);
                                 message.setProperty(org.wso2.carbon.messaging.Constants.DIRECTION,
                                         org.wso2.carbon.messaging.Constants.DIRECTION_RESPONSE);
+                                message.setProperty
+                                        (org.wso2.transport.file.connector.server.util.Constants.FILE_PATH , filePath);
+                                line = bufferedReader.readLine();
+                                while (line != null && line.isEmpty()) {
+                                    line = bufferedReader.readLine();
+                                }
+                                if (line == null) {
+                                    message.setProperty
+                                            (org.wso2.transport.file.connector.server.util.Constants.EOF , true);
+                                } else {
+                                    message.setProperty
+                                            (org.wso2.transport.file.connector.server.util.Constants.EOF , false);
+                                }
                                 carbonMessageProcessor.receive(message, carbonCallback);
                             }
                         } else {
@@ -202,6 +217,8 @@ public class VFSClientConnector implements ClientConnector {
                                     wrap(toByteArray(inputStream)), true);
                             message.setProperty(org.wso2.carbon.messaging.Constants.DIRECTION,
                                     org.wso2.carbon.messaging.Constants.DIRECTION_RESPONSE);
+                            message.setProperty
+                                    (org.wso2.transport.file.connector.server.util.Constants.FILE_PATH , filePath);
                             carbonMessageProcessor.receive(message, carbonCallback);
                         }
                     } else {
@@ -212,8 +229,8 @@ public class VFSClientConnector implements ClientConnector {
                 case Constants.EXISTS:
                     TextCarbonMessage message = new TextCarbonMessage(Boolean.toString(path.exists()));
                     message.setProperty(org.wso2.carbon.messaging.Constants.DIRECTION,
-                                        org.wso2.carbon.messaging.Constants.DIRECTION_RESPONSE);
-                    carbonMessageProcessor.receive(message, carbonCallback);
+                            org.wso2.carbon.messaging.Constants.DIRECTION_RESPONSE);
+                    carbonMessageProcessor.receive(message , carbonCallback);
                     break;
                 default:
                     return false;

--- a/components/org.wso2.transport.file/src/main/java/org/wso2/transport/file/connector/sender/VFSClientConnector.java
+++ b/components/org.wso2.transport.file/src/main/java/org/wso2/transport/file/connector/sender/VFSClientConnector.java
@@ -106,7 +106,8 @@ public class VFSClientConnector implements ClientConnector {
                     if (isFolder) {
                         path.createFolder();
                     } else {
-                        path.createFile(); }
+                        path.createFile();
+                    }
                     break;
                 case Constants.WRITE:
                     if (!path.exists()) {
@@ -205,8 +206,7 @@ public class VFSClientConnector implements ClientConnector {
                                     message.setProperty(org.wso2.transport.file.connector.server.util.Constants.EOF,
                                             true);
                                 } else {
-                                    message.setProperty
-                                            (org.wso2.transport.file.connector.server.util.Constants.EOF,
+                                    message.setProperty(org.wso2.transport.file.connector.server.util.Constants.EOF,
                                                     false);
                                 }
                                 carbonMessageProcessor.receive(message, carbonCallback);
@@ -230,7 +230,7 @@ public class VFSClientConnector implements ClientConnector {
                     TextCarbonMessage message = new TextCarbonMessage(Boolean.toString(path.exists()));
                     message.setProperty(org.wso2.carbon.messaging.Constants.DIRECTION,
                             org.wso2.carbon.messaging.Constants.DIRECTION_RESPONSE);
-                    carbonMessageProcessor.receive(message , carbonCallback);
+                    carbonMessageProcessor.receive(message, carbonCallback);
                     break;
                 default:
                     return false;

--- a/components/org.wso2.transport.file/src/main/java/org/wso2/transport/file/connector/sender/VFSClientConnector.java
+++ b/components/org.wso2.transport.file/src/main/java/org/wso2/transport/file/connector/sender/VFSClientConnector.java
@@ -207,7 +207,7 @@ public class VFSClientConnector implements ClientConnector {
                                             true);
                                 } else {
                                     message.setProperty(org.wso2.transport.file.connector.server.util.Constants.EOF,
-                                                    false);
+                                            false);
                                 }
                                 carbonMessageProcessor.receive(message, carbonCallback);
                             }

--- a/components/org.wso2.transport.file/src/main/java/org/wso2/transport/file/connector/sender/VFSClientConnector.java
+++ b/components/org.wso2.transport.file/src/main/java/org/wso2/transport/file/connector/sender/VFSClientConnector.java
@@ -106,8 +106,7 @@ public class VFSClientConnector implements ClientConnector {
                     if (isFolder) {
                         path.createFolder();
                     } else {
-                        path.createFile();
-                    }
+                        path.createFile(); }
                     break;
                 case Constants.WRITE:
                     if (!path.exists()) {
@@ -196,18 +195,19 @@ public class VFSClientConnector implements ClientConnector {
                                         wrap(line.getBytes(StandardCharsets.UTF_8)), true);
                                 message.setProperty(org.wso2.carbon.messaging.Constants.DIRECTION,
                                         org.wso2.carbon.messaging.Constants.DIRECTION_RESPONSE);
-                                message.setProperty
-                                        (org.wso2.transport.file.connector.server.util.Constants.FILE_PATH , filePath);
+                                message.setProperty(org.wso2.transport.file.connector.server.util.Constants.FILE_PATH,
+                                        filePath);
                                 line = bufferedReader.readLine();
                                 while (line != null && line.isEmpty()) {
                                     line = bufferedReader.readLine();
                                 }
                                 if (line == null) {
-                                    message.setProperty
-                                            (org.wso2.transport.file.connector.server.util.Constants.EOF , true);
+                                    message.setProperty(org.wso2.transport.file.connector.server.util.Constants.EOF,
+                                            true);
                                 } else {
                                     message.setProperty
-                                            (org.wso2.transport.file.connector.server.util.Constants.EOF , false);
+                                            (org.wso2.transport.file.connector.server.util.Constants.EOF,
+                                                    false);
                                 }
                                 carbonMessageProcessor.receive(message, carbonCallback);
                             }
@@ -217,8 +217,8 @@ public class VFSClientConnector implements ClientConnector {
                                     wrap(toByteArray(inputStream)), true);
                             message.setProperty(org.wso2.carbon.messaging.Constants.DIRECTION,
                                     org.wso2.carbon.messaging.Constants.DIRECTION_RESPONSE);
-                            message.setProperty
-                                    (org.wso2.transport.file.connector.server.util.Constants.FILE_PATH , filePath);
+                            message.setProperty(org.wso2.transport.file.connector.server.util.Constants.FILE_PATH,
+                                    filePath);
                             carbonMessageProcessor.receive(message, carbonCallback);
                         }
                     } else {

--- a/components/org.wso2.transport.file/src/main/java/org/wso2/transport/file/connector/server/util/Constants.java
+++ b/components/org.wso2.transport.file/src/main/java/org/wso2/transport/file/connector/server/util/Constants.java
@@ -49,6 +49,8 @@ public final class Constants {
     public static final String FILE_UPDATE = "FILE_UPDATE";
     public static final String FILE_ROTATE = "FILE_ROTATE";
     public static final String FILE_TRANSPORT_EVENT_NAME = "FILE_TRANSPORT_EVENT_NAME";
+    public static final String FILE_PATH = "file.path";
+    public static final String EOF = "eof";
 
     private Constants() {
     }


### PR DESCRIPTION
## Purpose
> The user needs to be Alerted when a file is done the processing.

## Goals
> Change the introduced transport property 'eof'  to true at the source level after reading the file.
> Introduce the 'trp:file.path' property to pass the file location to the siddhi app.
> Siddhi query can check.

## Release note
> The 'eof' transport property (trp:eof) will change to true and pass when the completion of file processing.
> The 'trp:file.path' property will pass the file location to the siddhi app.
 