### PR TITLE
Add skipping file header read functionality

### DIFF
--- a/components/org.wso2.transport.file/src/main/java/org/wso2/transport/file/connector/sender/Constants.java
+++ b/components/org.wso2.transport.file/src/main/java/org/wso2/transport/file/connector/sender/Constants.java
@@ -37,7 +37,6 @@ public final class Constants {
     public static final String MOVE = "move";
     public static final String READ = "read";
     public static final String EXISTS = "exists";
-    public static final String SIZE = "size";
     public static final String FILE_READ_WAIT_TIMEOUT = "fileReadWaitTimeout";
     public static final String MODE = "mode";
     public static final String MODE_TYPE_LINE = "line";

--- a/components/org.wso2.transport.file/src/main/java/org/wso2/transport/file/connector/sender/Constants.java
+++ b/components/org.wso2.transport.file/src/main/java/org/wso2/transport/file/connector/sender/Constants.java
@@ -37,9 +37,11 @@ public final class Constants {
     public static final String MOVE = "move";
     public static final String READ = "read";
     public static final String EXISTS = "exists";
+    public static final String SIZE = "size";
     public static final String FILE_READ_WAIT_TIMEOUT = "fileReadWaitTimeout";
     public static final String MODE = "mode";
     public static final String MODE_TYPE_LINE = "line";
+    public static final String HEADER_PRESENT = "header.present";
 
 
     // Constants for FTP protocol related configurations

--- a/components/org.wso2.transport.file/src/main/java/org/wso2/transport/file/connector/sender/VFSClientConnector.java
+++ b/components/org.wso2.transport.file/src/main/java/org/wso2/transport/file/connector/sender/VFSClientConnector.java
@@ -212,9 +212,8 @@ public class VFSClientConnector implements ClientConnector {
                                 }
                                 if (headerSkipped) {
                                     carbonMessageProcessor.receive(message, carbonCallback);
-                                } else {
-                                    headerSkipped = true;
                                 }
+                                headerSkipped = true;
                             }
                         } else {
                             inputStream = path.getContent().getInputStream();

--- a/components/org.wso2.transport.file/src/main/java/org/wso2/transport/file/connector/sender/VFSClientConnector.java
+++ b/components/org.wso2.transport.file/src/main/java/org/wso2/transport/file/connector/sender/VFSClientConnector.java
@@ -187,6 +187,7 @@ public class VFSClientConnector implements ClientConnector {
                         String mode = map.get(Constants.MODE);
                         if (Constants.MODE_TYPE_LINE.equalsIgnoreCase(mode) &&
                                 !fileExtension.equalsIgnoreCase(Constants.BINARY_FILE_EXTENSION)) {
+                            boolean headerSkipped = !Boolean.parseBoolean(map.get(Constants.HEADER_PRESENT));
                             bufferedReader = Files.newBufferedReader(Paths.get(filePath));
                             String line;
                             BinaryCarbonMessage message;
@@ -209,7 +210,11 @@ public class VFSClientConnector implements ClientConnector {
                                     message.setProperty(org.wso2.transport.file.connector.server.util.Constants.EOF,
                                             false);
                                 }
-                                carbonMessageProcessor.receive(message, carbonCallback);
+                                if (headerSkipped) {
+                                    carbonMessageProcessor.receive(message, carbonCallback);
+                                } else {
+                                    headerSkipped = true;
+                                }
                             }
                         } else {
                             inputStream = path.getContent().getInputStream();


### PR DESCRIPTION
## Purpose
> Skip file header when available

## Approach
> Send a parameter called 'header.present' which mentions the particular file contains header or not

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes