### PR TITLE
Add functionality for read.only.header

### DIFF
--- a/components/org.wso2.transport.file/src/main/java/org/wso2/transport/file/connector/sender/Constants.java
+++ b/components/org.wso2.transport.file/src/main/java/org/wso2/transport/file/connector/sender/Constants.java
@@ -41,7 +41,7 @@ public final class Constants {
     public static final String MODE = "mode";
     public static final String MODE_TYPE_LINE = "line";
     public static final String HEADER_PRESENT = "header.present";
-
+    public static final String READ_ONLY_HEADER = "read.only.header";
 
     // Constants for FTP protocol related configurations
     public static final String FTP_PASSIVE_MODE = "FTP_PASSIVE_MODE";


### PR DESCRIPTION
## Purpose
> Add functionality for parameter 'read.only.header' 
The read.only.header is a new parameter used to get the header details of a file which contains event. if the value is set to true it will throw event with header detail. Else it will continue it process.
Fixes : https://github.com/siddhi-io/siddhi-io-file/issues/88 
https://github.com/wso2/streaming-integrator/issues/97
## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes