### PR TITLE
Fix setting FileSystemOptions when fileUri is Dynamic

### DIFF
--- a/components/org.wso2.transport.file/src/main/java/org/wso2/transport/file/connector/sender/Constants.java
+++ b/components/org.wso2.transport.file/src/main/java/org/wso2/transport/file/connector/sender/Constants.java
@@ -27,6 +27,7 @@ public final class Constants {
     public static final String PROTOCOL_FTP = "ftp";
     public static final String PROTOCOL_SFTP = "sftp";
     public static final String BINARY_FILE_EXTENSION = "bin";
+    public static final String PROTOCOL = "PROTOCOL";
 
     public static final String APPEND = "append";
     public static final String FILE_URI = "uri";


### PR DESCRIPTION
## Purpose
> $subject

## Goals
> set file system options when the file uri is dynamic

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes