### PR TITLE
Fix path exceptions when remote file locations are given

### DIFF
--- a/components/org.wso2.transport.remote-file-system/src/main/java/org/wso2/transport/remotefilesystem/server/RemoteFileSystemConsumer.java
+++ b/components/org.wso2.transport.remote-file-system/src/main/java/org/wso2/transport/remotefilesystem/server/RemoteFileSystemConsumer.java
@@ -229,7 +229,7 @@ public class RemoteFileSystemConsumer {
                         directoryHandler(c);
                     }
                 } else {
-                    current.add(child.getName().getPath());
+                    current.add(child.getName().getURI());
                     fileHandler(child);
                 }
             }
@@ -242,8 +242,8 @@ public class RemoteFileSystemConsumer {
      * @param file A single file to be processed
      */
     private void fileHandler(FileObject file) throws FileSystemException {
-        String path = file.getName().getPath();
-        if (processed.contains(file.getName().getPath())) {
+        String path = file.getName().getURI();
+        if (processed.contains(file.getName().getURI())) {
             return;
         }
         FileInfo info = new FileInfo(path);

--- a/components/org.wso2.transport.remote-file-system/src/main/java/org/wso2/transport/remotefilesystem/server/RemoteFileSystemConsumer.java
+++ b/components/org.wso2.transport.remote-file-system/src/main/java/org/wso2/transport/remotefilesystem/server/RemoteFileSystemConsumer.java
@@ -243,7 +243,7 @@ public class RemoteFileSystemConsumer {
      */
     private void fileHandler(FileObject file) throws FileSystemException {
         String path = file.getName().getURI();
-        if (processed.contains(file.getName().getURI())) {
+        if (processed.contains(path)) {
             return;
         }
         FileInfo info = new FileInfo(path);


### PR DESCRIPTION
## Purpose
> $subject

## Approach
> when using getPath(), it truncates "ftp:/bob:password@localhost:22" from the path which then gives an file not found exception when the reading the path.
> getURI() will give the absolute path given

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes