### PR TITLE
Fix for https://github.com/wso2/streaming-integrator/issues/184

### DIFF
--- a/components/org.wso2.transport.file/src/main/java/org/wso2/transport/file/connector/sender/Constants.java
+++ b/components/org.wso2.transport.file/src/main/java/org/wso2/transport/file/connector/sender/Constants.java
@@ -37,6 +37,9 @@ public final class Constants {
     public static final String DELETE = "delete";
     public static final String COPY = "copy";
     public static final String MOVE = "move";
+    public static final String MOVE_IF_EXIST_KEEP = "keep";
+    public static final String MOVE_IF_EXIST_OVERWRITE = "overwrite";
+    public static final String MOVE_IF_EXIST_MODE = "move.if.exist.mode";
     public static final String READ = "read";
     public static final String EXISTS = "exists";
     public static final String FILE_READ_WAIT_TIMEOUT = "fileReadWaitTimeout";


### PR DESCRIPTION
Add improvement to overwrite or create a new file if file already exist in file move operation.
Fix provided by @dnwick 

## Approach
This PR introduces a new property move.if.exist.mode which allows the users to specify what to do if the destination has a file with the same name as the moved file. Possible values are keep and overwrite.

## Release note
Introduced a new property move.if.exist.mode which allows the users to specify what to do if the destination has a file with the same name as the moved file. Possible values are keep and overwrite

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Related PRs
TODO

## Test environment
Ran unit tests in JDK 1.8.0_171