### PR TITLE
Add support to skip multi-line headers

### DIFF
--- a/components/org.wso2.transport.file/src/main/java/org/wso2/transport/file/connector/sender/Constants.java
+++ b/components/org.wso2.transport.file/src/main/java/org/wso2/transport/file/connector/sender/Constants.java
@@ -58,6 +58,7 @@ public final class Constants {
     public static final String IDENTITY = "IDENTITY";
     public static final String IDENTITY_PASS_PHRASE = "IDENTITY_PASS_PHRASE";
     public static final String AVOID_PERMISSION_CHECK = "AVOID_PERMISSION_CHECK";
+    public static final String HEADER_LINE_COUNT = "header.line.count";
 
     private Constants() {
     }

--- a/components/org.wso2.transport.file/src/main/java/org/wso2/transport/file/connector/sender/VFSClientConnector.java
+++ b/components/org.wso2.transport.file/src/main/java/org/wso2/transport/file/connector/sender/VFSClientConnector.java
@@ -283,7 +283,12 @@ public class VFSClientConnector implements ClientConnector {
                             boolean readOnlyHeader = Boolean.parseBoolean(map.get(Constants.READ_ONLY_HEADER));
                             boolean readOnlyTrailer = Boolean.parseBoolean(map.get(Constants.READ_ONLY_TRAILER));
                             boolean trailerSkipped = Boolean.parseBoolean(map.get(Constants.SKIP_TRAILER));
-                            boolean headerSkipped = !Boolean.parseBoolean(map.get(Constants.HEADER_PRESENT));
+                            int headerLineCount = 0;
+                            if (Boolean.parseBoolean(map.get(Constants.HEADER_PRESENT))) {
+                                String headerLineCountValue = map.get(Constants.HEADER_LINE_COUNT);
+                                headerLineCount =  (headerLineCountValue != null) ?
+                                        Integer.parseInt(headerLineCountValue) : 1;
+                            }
                             String line;
                             BinaryCarbonMessage message;
                             line = bufferedReader.readLine();
@@ -374,6 +379,7 @@ public class VFSClientConnector implements ClientConnector {
                                     }
                                 }
                             } else {
+                                int remainingHeaderLines = headerLineCount;
                                 while (line != null) {
                                     message = new BinaryCarbonMessage(ByteBuffer.
                                             wrap(line.getBytes(StandardCharsets.UTF_8)), true);
@@ -393,10 +399,10 @@ public class VFSClientConnector implements ClientConnector {
                                         message.setProperty(org.wso2.transport.file.connector.server.util.Constants.EOF,
                                                 false);
                                     }
-                                    if (headerSkipped) {
+                                    if (remainingHeaderLines == 0) {
                                         carbonMessageProcessor.receive(message, carbonCallback);
                                     } else {
-                                        headerSkipped = true;
+                                        remainingHeaderLines--;
                                     }
                                 }
                             }


### PR DESCRIPTION
## Purpose
`Transport-file` support ignoring the file header line by setting the `header.present` parameter to `true`. But this only ignores the first line of the file. This needs to be modified to cater to files with multi-line headers.

Related to https://github.com/wso2/api-manager/issues/2056

## Approach
A new parameter, `header.line.count` is introduced to specify the number of header lines to ignore. This needs to be used along with the parameter, `header.present='true'`. The default value is `1`.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes