### PR TITLE
Add skipping multi-line headers while skip.trailer is true

### DIFF
--- a/components/org.wso2.transport.file/src/main/java/org/wso2/transport/file/connector/sender/VFSClientConnector.java
+++ b/components/org.wso2.transport.file/src/main/java/org/wso2/transport/file/connector/sender/VFSClientConnector.java
@@ -336,7 +336,7 @@ public class VFSClientConnector implements ClientConnector {
                                         true);
                                 carbonMessageProcessor.receive(message, carbonCallback);
                             } else if (trailerSkipped && line != null) {
-                                boolean skipSendingLine = Boolean.parseBoolean(map.get(Constants.HEADER_PRESENT));
+                                int remainingHeaderLines = headerLineCount;
                                 String nextLine = bufferedReader.readLine();
                                 while (nextLine != null && nextLine.isEmpty()) {
                                     nextLine = bufferedReader.readLine();
@@ -361,7 +361,7 @@ public class VFSClientConnector implements ClientConnector {
                                     while (lineAfterNextLine != null && lineAfterNextLine.isEmpty()) {
                                         lineAfterNextLine = bufferedReader.readLine();
                                     }
-                                    if (!skipSendingLine) {
+                                    if (remainingHeaderLines == 0) {
                                         if (line != null) {
                                             boolean isEOFAfterNextLine =
                                                     nextLine == null && lineAfterNextLine == null;
@@ -375,7 +375,7 @@ public class VFSClientConnector implements ClientConnector {
                                             }
                                         }
                                     } else {
-                                        skipSendingLine = false;
+                                        remainingHeaderLines--;
                                     }
                                 }
                             } else {


### PR DESCRIPTION
## Purpose
This PR adds support to skip multi-line headers while the `skip.trailer` parameter is `true`.

Related to https://github.com/wso2/api-manager/issues/2056

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
## Related PRs
- https://github.com/wso2/transport-file/pull/33